### PR TITLE
Raise timeout errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# A sample Gemfile
 source 'https://rubygems.org'
 
 gemspec
@@ -7,4 +6,5 @@ gem 'rake'
 
 group :test do
   gem 'rspec', '>= 3.1'
+  gem 'timecop', '~> 0.8.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    timecop (0.8.1)
 
 PLATFORMS
   ruby
@@ -31,6 +32,7 @@ DEPENDENCIES
   circuit_breaker-ruby!
   rake
   rspec (>= 3.1)
+  timecop (~> 0.8.1)
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/lib/circuit_breaker-ruby.rb
+++ b/lib/circuit_breaker-ruby.rb
@@ -5,6 +5,7 @@ require 'timeout'
 
 module CircuitBreaker
   class Open < StandardError; end
+  class TimeoutError < StandardError; end
 
   class << self
     def config


### PR DESCRIPTION
* Raise `CircuitBreaker::TimeoutError` in case of timeouts
* Memoize `reached_failure_threshold?` calculation
* Refactor test cases to be more verbose
* Use `timecop` in specs to simulate time travel