### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog for v0.1.x
+
+## v0.1.3 (2019-03-12)
+
+### Bug fixes
+
+  * Total count is not getting incremented incase of exception is raised
+  * total_count reset to 0 when state is in half_open
+  * reached_failure_threshold? returns only true once it is set to true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    circuit_breaker-ruby (0.1.2)
+    circuit_breaker-ruby (0.1.3)
       rake (>= 10)
       rspec (>= 3)
 
@@ -35,4 +35,4 @@ DEPENDENCIES
   timecop (~> 0.8.1)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/lib/circuit_breaker-ruby/version.rb
+++ b/lib/circuit_breaker-ruby/version.rb
@@ -1,3 +1,3 @@
 module CircuitBreaker
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
## v0.1.3 (2019-03-12)

### Bug fixes

  * Total count is not getting incremented incase of exception is raised
  * total_count reset to 0 when state is in half_open
  * reached_failure_threshold? returns only true once it is set to true